### PR TITLE
Fix #5: Add PATH refresh after tool installations (v0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-12-24
+
+### Fixed
+
+- **PATH Refresh Issue** - Fixed issue where Git and other tools installed via winget were not immediately available in the current PowerShell session ([#5](https://github.com/mastrauckas/install-scripts/issues/5))
+  - After installing tools via winget, the current session's PATH environment variable was not updated
+  - This caused subsequent Git commands (git config, git clone) to fail with "git is not recognized"
+  - Script now refreshes the session environment after each installation, making tools immediately available
+
+### Added
+
+- **Environment Refresh Functions** - New PowerShell functions to refresh session environment variables from registry
+  - `Update-SessionEnvironment` - Refreshes all environment variables from Machine and User registry scopes
+  - `Get-EnvironmentVariableNames` - Retrieves environment variable names for a given scope
+  - `Get-EnvironmentVariableValue` - Retrieves environment variable values from registry
+  - Combines and deduplicates PATH entries from both Machine and User scopes
+  - Preserves session-critical variables (PSModulePath, USERNAME, PROCESSOR_ARCHITECTURE)
+  - Safe to call multiple times (idempotent)
+
 ## [0.1.1] - 2025-12-23
 
 ### Fixed
@@ -75,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error handling with try-catch blocks and descriptive messages
 - User-scoped registry changes (HKCU) for personalization settings
 
-[unreleased]: https://github.com/mastrauckas/install-scripts/compare/v0.1.1...HEAD
+[unreleased]: https://github.com/mastrauckas/install-scripts/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/mastrauckas/install-scripts/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/mastrauckas/install-scripts/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mastrauckas/install-scripts/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Fixes #5 - Adds automatic PATH refresh after tool installations to make newly installed tools immediately available in the current PowerShell session.

## Problem

When running `windows\install.ps1`, tools installed via winget (Git, PowerShell, VS Code Insiders) were not immediately available in the current session, causing "git is not recognized" errors when the script tried to run Git commands.

## Solution

Added `Update-SessionEnvironment` function that:
- Refreshes environment variables from the Windows registry
- Combines Machine and User PATH entries
- Deduplicates PATH entries
- Preserves session-critical variables (PSModulePath, USERNAME, PROCESSOR_ARCHITECTURE)
- Is idempotent and safe to call multiple times

The function is called after each winget installation to ensure newly installed tools are immediately available.

## Changes

- Added three new functions in `windows\install.ps1`:
  - `Update-SessionEnvironment` - Main refresh function
  - `Get-EnvironmentVariableNames` - Helper to retrieve env var names from registry
  - `Get-EnvironmentVariableValue` - Helper to retrieve env var values from registry
- Added `Update-SessionEnvironment` calls after:
  - `Install-PowerShell`
  - `Install-Chocolatey`
  - `Install-Git` (critical for fixing the issue)
  - `Install-VSCodeInsiders`
- Updated script version to 0.1.2
- Updated CHANGELOG.md with detailed v0.1.2 entry

## Testing

This fix enables the script to run end-to-end without requiring manual PowerShell session restart. Git configuration and repository cloning now work immediately after Git installation.

## Related Issue

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
